### PR TITLE
Link to core webxdc page

### DIFF
--- a/src/04_cookbook.md
+++ b/src/04_cookbook.md
@@ -5,3 +5,5 @@
 In this chapter you can find small code snippets (recipes) that help you implement some commonly used features, such as scoreboards for adding a highscore to your game.
 
 Feel free to contribute recipies that you find useful on [github](https://github.com/deltachat/webxdc_docs).
+
+(As this section is being written, you might find more examples in the [core library](https://github.com/deltachat/deltachat-core-rust/blob/master/draft/webxdc-dev-reference.md)).


### PR DESCRIPTION
The linked page will probably be merged with this repo in some way, but until then it's useful to reference it.