### PR TITLE
Get rid of the last "*status* update" mention

### DIFF
--- a/src/spec/sendUpdate.md
+++ b/src/spec/sendUpdate.md
@@ -4,7 +4,7 @@
 window.webxdc.sendUpdate(update, descr);
 ```
 
-Send a status update to all peers.
+Send an update to all peers.
 
 - `update`: an object with the following properties:  
     - `update.payload`: string, number, boolean, array, object or `null`.


### PR DESCRIPTION
It is misleading, webxdc updates are usually CRDT document updates and not status ("user is typing", "user is online") updates.